### PR TITLE
fix:取消菜单绑定后显示依然绑定

### DIFF
--- a/api/system/role.go
+++ b/api/system/role.go
@@ -192,7 +192,7 @@ func (r Role) GetRoleMenusApi(ctx *gin.Context) {
 
 	var menus []model.MenuEntity
 	err := global.AquilaDb.Joins("JOIN role_menu ON role_menu.menu_id = menu.id").
-		Where("role_menu.role_id = ?", roleId).
+		Where("role_menu.role_id = ? AND role_menu.deleted_at IS NULL", roleId).
 		Find(&menus).Error
 
 	if err != nil {


### PR DESCRIPTION
角色勾选取消后仍然有选中角色
<img width="790" alt="image" src="https://github.com/user-attachments/assets/ee2e2ae1-996b-459d-94d9-d4ff5cd59843" />
